### PR TITLE
Fix billing controller exports and Stripe webhook routing

### DIFF
--- a/server.js
+++ b/server.js
@@ -7,6 +7,7 @@ const express = require("express");
 const cookieSession = require("cookie-session");
 const sessionMiddleware = require("./middleware/authMiddleware");
 const errorHandler = require("./middleware/errorHandler");
+const { handleStripeWebhook } = require("./controllers/billingController");
 
 const app = express();
 const PORT = process.env.PORT || 5173;
@@ -16,6 +17,12 @@ const SESSION_SECRET = process.env.SESSION_SECRET || "dev-secret";
 // ───────────────────────────────────────────────────────────────────────────────
 // core middleware
 // ───────────────────────────────────────────────────────────────────────────────
+app.post(
+  "/billing/webhook",
+  express.raw({ type: "application/json" }),
+  handleStripeWebhook
+);
+
 app.use(express.json({ limit: "1mb" }));
 app.use(
   cookieSession({


### PR DESCRIPTION
## Summary
- restore billing controller to export request handlers for subscription endpoints
- add a dedicated Stripe webhook handler that updates subscriptions based on webhook events
- mount the webhook route before JSON parsing so Stripe requests keep the raw body

## Testing
- `node server.js`


------
https://chatgpt.com/codex/tasks/task_e_68c9ad397798832abd35f5ac71fa4fff