### PR TITLE
Add Stripe-powered support page

### DIFF
--- a/controllers/billingController.js
+++ b/controllers/billingController.js
@@ -5,6 +5,7 @@ const {
 const { stripe, WEBHOOK_SECRET } = require("../config/stripe");
 const PRICE_BASIC = process.env.STRIPE_PRICE_ID;
 const PRICE_PRO = process.env.STRIPE_PRICE_ID_PREMIUM;
+const DONATION_PRODUCT_NAME = "Support InboxVetter";
 
 function ensureEmail(req, res) {
   const email = req.session?.user?.email;
@@ -58,6 +59,61 @@ exports.startCheckout = async (req, res) => {
     res.json({ ok: true, url: session.url, id: session.id });
   } catch (err) {
     console.error('Checkout error:', err);
+    res.status(500).json({ ok: false, error: err.message });
+  }
+};
+
+exports.startSupportCheckout = async (req, res) => {
+  const email = ensureEmail(req, res);
+  if (!email) return;
+
+  const rawAmount = req.body?.amount;
+  const amountNumber = typeof rawAmount === "string" ? parseFloat(rawAmount) : Number(rawAmount);
+  const amountInCents = Math.round((amountNumber || 0) * 100);
+
+  if (!Number.isFinite(amountNumber) || amountInCents < 100) {
+    return res.status(400).json({
+      ok: false,
+      error: "Donation amount must be at least $1",
+    });
+  }
+
+  if (amountInCents > 1000000) {
+    return res.status(400).json({
+      ok: false,
+      error: "Donation amount is too large",
+    });
+  }
+
+  try {
+    const session = await stripe.checkout.sessions.create({
+      mode: "payment",
+      payment_method_types: ["card"],
+      customer_email: email,
+      line_items: [
+        {
+          quantity: 1,
+          price_data: {
+            currency: "usd",
+            unit_amount: amountInCents,
+            product_data: {
+              name: DONATION_PRODUCT_NAME,
+            },
+          },
+        },
+      ],
+      metadata: {
+        email,
+        type: "donation",
+        amount_cents: amountInCents.toString(),
+      },
+      success_url: `${req.protocol}://${req.get("host")}/supportme.html?success=1`,
+      cancel_url: `${req.protocol}://${req.get("host")}/supportme.html?canceled=1`,
+    });
+
+    res.json({ ok: true, url: session.url, id: session.id });
+  } catch (err) {
+    console.error("Support checkout error:", err);
     res.status(500).json({ ok: false, error: err.message });
   }
 };

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -42,6 +42,14 @@
       </div>
     </section>
 
+    <section class="bg-white border border-slate-200 rounded-xl p-5 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+      <div>
+        <h2 class="text-lg font-semibold">Support InboxVetter</h2>
+        <p class="text-sm text-slate-600">Enjoying your vetted inbox? Chip in any amount to help keep new features coming.</p>
+      </div>
+      <a href="/supportme.html" class="text-sm px-3 py-1.5 rounded-lg bg-amber-500 text-white hover:bg-amber-400">Donate with Stripe</a>
+    </section>
+
     <section>
       <div class="mb-4 flex items-center justify-between">
         <h2 class="text-lg font-semibold">Reports</h2>

--- a/public/login.html
+++ b/public/login.html
@@ -11,6 +11,7 @@
     <div id="gbtn" style="display:inline-block;margin-top:14px"></div>
     <p class="status" style="margin-top:14px">Local demo · settings are stored in the local JSON database.</p>
     <p style="margin-top:10px;font-size:12px;color:#64748b">By continuing, you agree to our <a href="/tos" style="color:#4f46e5">Terms</a> and <a href="/policy" style="color:#4f46e5">Privacy Policy</a>.</p>
+    <p style="margin-top:10px;font-size:12px;color:#64748b">Want to support InboxVetter? <a href="/supportme.html" style="color:#4f46e5">Donate here</a>.</p>
   </div>
 
 <script>

--- a/public/supportme.html
+++ b/public/supportme.html
@@ -1,0 +1,165 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Support InboxVetter</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-slate-50 text-slate-900">
+  <header class="w-full bg-white border-b border-slate-200">
+    <div class="max-w-3xl mx-auto px-4 py-4 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <div class="h-8 w-8 rounded-xl bg-indigo-600"></div>
+        <div>
+          <h1 class="text-xl font-semibold">InboxVetter</h1>
+          <p class="text-xs text-slate-500">Support the project</p>
+        </div>
+      </div>
+      <a href="/dashboard.html" class="text-sm px-3 py-1.5 rounded-lg border border-slate-300 hover:bg-slate-100">Back to dashboard</a>
+    </div>
+  </header>
+
+  <main class="max-w-3xl mx-auto px-4 py-10">
+    <section class="bg-white border border-slate-200 rounded-xl p-6 space-y-6">
+      <div>
+        <h2 class="text-2xl font-semibold">Buy us a coffee ☕</h2>
+        <p class="mt-2 text-sm text-slate-600">
+          InboxVetter stays alive thanks to people like you. Choose any amount below and you'll be redirected to Stripe to complete the donation.
+        </p>
+        <p id="supportEmailWrap" class="mt-2 text-xs text-slate-500 hidden">
+          Your donation will be associated with <span id="supportEmail" class="font-medium"></span>.
+        </p>
+      </div>
+
+      <form id="supportForm" class="space-y-4">
+        <div>
+          <label for="amount" class="block text-sm font-medium text-slate-700">Donation amount (USD)</label>
+          <div class="mt-1 relative rounded-lg shadow-sm">
+            <div class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-slate-400">$</div>
+            <input
+              type="number"
+              id="amount"
+              name="amount"
+              min="1"
+              step="0.01"
+              required
+              inputmode="decimal"
+              placeholder="10.00"
+              class="block w-full rounded-lg border border-slate-300 pl-7 pr-3 py-2 focus:border-indigo-500 focus:ring-indigo-500 text-sm"
+            />
+          </div>
+          <p class="mt-1 text-xs text-slate-500">Minimum donation is $1.00.</p>
+        </div>
+
+        <button
+          type="submit"
+          id="supportSubmit"
+          class="w-full sm:w-auto inline-flex justify-center text-sm font-medium px-4 py-2 rounded-lg bg-indigo-600 text-white hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+        >Donate with Stripe</button>
+
+        <div id="message" class="hidden mt-4 text-sm rounded-lg border px-4 py-3"></div>
+      </form>
+    </section>
+  </main>
+
+  <script>
+    const messageEl = document.getElementById('message');
+    const messageBaseClass = 'mt-4 text-sm rounded-lg border px-4 py-3';
+    const messageVariants = {
+      success: 'border-green-200 bg-green-50 text-green-700',
+      error: 'border-red-200 bg-red-50 text-red-700',
+      info: 'border-blue-200 bg-blue-50 text-blue-700'
+    };
+
+    function showMessage(type, text) {
+      const variant = messageVariants[type] || messageVariants.info;
+      messageEl.className = `${messageBaseClass} ${variant}`;
+      messageEl.textContent = text;
+    }
+
+    function hideMessage() {
+      messageEl.className = `${messageBaseClass} hidden`;
+      messageEl.textContent = '';
+    }
+
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('success')) {
+      showMessage('success', 'Thank you! Your donation was received successfully.');
+      window.history.replaceState({}, document.title, window.location.pathname);
+    } else if (params.get('canceled')) {
+      showMessage('error', 'Donation canceled. Feel free to try again whenever you are ready.');
+      window.history.replaceState({}, document.title, window.location.pathname);
+    } else {
+      hideMessage();
+    }
+
+    async function fetchProfile() {
+      try {
+        const res = await fetch('/api/me', { credentials: 'include' });
+        if (!res.ok) return;
+        const data = await res.json();
+        const email = data?.user?.email;
+        if (email) {
+          const wrap = document.getElementById('supportEmailWrap');
+          const emailEl = document.getElementById('supportEmail');
+          emailEl.textContent = email;
+          wrap.classList.remove('hidden');
+        }
+      } catch (err) {
+        console.warn('Failed to load profile for donation page:', err);
+      }
+    }
+
+    fetchProfile();
+
+    const form = document.getElementById('supportForm');
+    const amountInput = document.getElementById('amount');
+    const submitBtn = document.getElementById('supportSubmit');
+    const defaultBtnText = submitBtn.textContent;
+
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const raw = amountInput.value.trim();
+      const amount = Number.parseFloat(raw);
+
+      if (!Number.isFinite(amount) || amount < 1) {
+        showMessage('error', 'Please enter a valid amount of at least $1.00.');
+        return;
+      }
+
+      hideMessage();
+      submitBtn.disabled = true;
+      submitBtn.textContent = 'Redirecting…';
+
+      let redirecting = false;
+
+      try {
+        const response = await fetch('/billing/support', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ amount })
+        });
+
+        const payload = await response.json().catch(() => ({}));
+
+        if (!response.ok || !payload?.ok || !payload?.url) {
+          const message = payload?.error || 'Unable to start the Stripe checkout session.';
+          throw new Error(message);
+        }
+
+        redirecting = true;
+        window.location.href = payload.url;
+      } catch (err) {
+        showMessage('error', err.message || 'Unexpected error. Please try again.');
+      } finally {
+        if (!redirecting) {
+          submitBtn.disabled = false;
+          submitBtn.textContent = defaultBtnText;
+        }
+      }
+    });
+  </script>
+</body>
+</html>

--- a/routes/billing.js
+++ b/routes/billing.js
@@ -6,10 +6,12 @@ const {
   getSubscription,
   updateSubscription,
   startCheckout,
+  startSupportCheckout,
 } = require("../controllers/billingController");
 
 router.get("/subscription", requireAuth, getSubscription);
 router.post("/subscription", requireAuth, updateSubscription);
 router.post("/checkout", requireAuth, startCheckout);
+router.post("/support", requireAuth, startSupportCheckout);
 
 module.exports = router;

--- a/server.js
+++ b/server.js
@@ -81,6 +81,9 @@ app.get(["/dashboard", "/dashboard.html"], sessionMiddleware.requireAuth, (_, re
 app.get(["/settings", "/settings.html"], sessionMiddleware.requireAuth, (_, res) =>
   res.sendFile(path.join(PUB, "settings.html"))
 );
+app.get(["/supportme", "/supportme.html"], sessionMiddleware.requireAuth, (_, res) =>
+  res.sendFile(path.join(PUB, "supportme.html"))
+);
 
 // ───────────────────────────────────────────────────────────────────────────────
 // routes


### PR DESCRIPTION
## Summary
- add a protected /supportme page with a Stripe donation form
- create a backend checkout flow that accepts custom donation amounts
- surface the new support call-to-action in the dashboard and login screen

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca04b6eda8832a9158ef5b68256a1a