### PR TITLE
Add build version footer

### DIFF
--- a/public/checkout.html
+++ b/public/checkout.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Checkout • InboxVetter</title>
   <script src="/theme.js"></script>
+  <script src="/config.js"></script>
+  <script src="/version.js" defer></script>
   <script src="https://cdn.tailwindcss.com"></script>
   <style>
     html[data-theme="dark"] body { background-color: #0f172a; color: #e2e8f0; }

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Dashboard</title>
   <script src="/theme.js"></script>
+  <script src="/config.js"></script>
+  <script src="/version.js" defer></script>
   <script src="https://cdn.tailwindcss.com"></script>
   <style>
     html[data-theme="dark"] body { background-color: #0f172a; color: #e2e8f0; }

--- a/public/devtest.html
+++ b/public/devtest.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>DevTest • Checkout</title>
   <script src="/theme.js"></script>
+  <script src="/config.js"></script>
+  <script src="/version.js" defer></script>
   <link rel="stylesheet" href="/style.css" />
   <style>
     .container { max-width: 760px; margin: 2rem auto; padding: 1.25rem; }

--- a/public/login.html
+++ b/public/login.html
@@ -4,6 +4,7 @@
 <script src="/theme.js"></script>
 <link rel="stylesheet" href="/style.css"/>
 <script src="/config.js"></script>
+<script src="/version.js" defer></script>
 <script src="https://accounts.google.com/gsi/client" async defer></script>
 </head><body>
   <div class="card" style="text-align:center">

--- a/public/policy.html
+++ b/public/policy.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Privacy Policy • InboxVetter</title>
   <script src="/theme.js"></script>
+  <script src="/config.js"></script>
+  <script src="/version.js" defer></script>
   <link rel="stylesheet" href="/style.css" />
   <style>
     .container { max-width: 800px; margin: 2rem auto; padding: 1.25rem; }

--- a/public/settings.html
+++ b/public/settings.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Settings</title>
   <script src="/theme.js"></script>
+  <script src="/config.js"></script>
+  <script src="/version.js" defer></script>
   <script src="https://cdn.tailwindcss.com"></script>
   <style>
     /* lightweight dark theme without Tailwind config */

--- a/public/supportme.html
+++ b/public/supportme.html
@@ -4,6 +4,9 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Support InboxVetter</title>
+  <script src="/theme.js"></script>
+  <script src="/config.js"></script>
+  <script src="/version.js" defer></script>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-slate-50 text-slate-900">

--- a/public/tos.html
+++ b/public/tos.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Terms of Service • InboxVetter</title>
   <script src="/theme.js"></script>
+  <script src="/config.js"></script>
+  <script src="/version.js" defer></script>
   <link rel="stylesheet" href="/style.css" />
   <style>
     .container { max-width: 800px; margin: 2rem auto; padding: 1.25rem; }

--- a/public/version.js
+++ b/public/version.js
@@ -1,0 +1,71 @@
+(function(){
+  function formatBuildTime(raw) {
+    if (!raw) return "";
+    try {
+      const date = new Date(raw);
+      if (!Number.isNaN(date.getTime())) {
+        return date.toLocaleString();
+      }
+    } catch (_) {}
+    return raw;
+  }
+
+  function renderFooter() {
+    if (!document.body) return;
+    if (document.getElementById("iv-version-footer")) return;
+
+    const cfg = (window.INBOXVETTER_CONFIG || {});
+    const version = cfg.VERSION ? `v${cfg.VERSION}` : "";
+    const buildTimeRaw = cfg.BUILD_TIME;
+    const buildTime = formatBuildTime(buildTimeRaw);
+    const commit = typeof cfg.BUILD_COMMIT === "string" ? cfg.BUILD_COMMIT : "";
+
+    const parts = [];
+    if (version) parts.push(version);
+    if (buildTime) parts.push(`built ${buildTime}`);
+    if (commit) parts.push(commit.slice(0, 7));
+
+    if (!parts.length) return;
+
+    const footer = document.createElement("div");
+    footer.id = "iv-version-footer";
+    footer.setAttribute("role", "contentinfo");
+    footer.textContent = `InboxVetter ${parts.join(" • ")}`;
+    const tooltip = [];
+    if (cfg.VERSION) tooltip.push(`Version: ${cfg.VERSION}`);
+    if (buildTimeRaw) tooltip.push(`Build time: ${buildTimeRaw}`);
+    if (commit) tooltip.push(`Commit: ${commit}`);
+    if (tooltip.length) footer.title = tooltip.join("\n");
+    footer.style.position = "fixed";
+    footer.style.right = "16px";
+    footer.style.bottom = "16px";
+    footer.style.zIndex = "2147483647";
+    footer.style.fontSize = "12px";
+    footer.style.fontFamily = "ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial";
+    footer.style.lineHeight = "1.4";
+    footer.style.padding = "6px 12px";
+    footer.style.borderRadius = "999px";
+    footer.style.backgroundColor = "rgba(15, 23, 42, 0.82)";
+    footer.style.color = "rgba(226, 232, 240, 0.95)";
+    footer.style.boxShadow = "0 8px 20px rgba(15, 23, 42, 0.25)";
+    footer.style.backdropFilter = "blur(8px)";
+    footer.style.pointerEvents = "none";
+
+    document.body.appendChild(footer);
+  }
+
+  function init() {
+    if (typeof window === "undefined") return;
+    if (!window.INBOXVETTER_CONFIG) {
+      window.addEventListener("INBOXVETTER_CONFIG_READY", renderFooter, { once: true });
+      return;
+    }
+    renderFooter();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
## Summary
- expose the package version and build metadata through `/config.js`
- add a shared front-end script that renders a persistent footer with the current build information
- include the new version footer on each static HTML page so updates are visible once deployed

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cb17f83b68832a9485da264f7efe16