### PR TITLE
Add union dashboard with vetter controls and report views

### DIFF
--- a/controllers/apiController.js
+++ b/controllers/apiController.js
@@ -4,6 +4,8 @@ const {
   getUser,
   listReports: listReportsFromStore,
   getReport: getReportFromStore,
+  getVetterState,
+  startVetterRun,
 } = require("../config/db");
 
 exports.getMe = (req, res) => {
@@ -27,6 +29,33 @@ exports.getReport = (req, res) => {
   const report = getReportFromStore(email, req.params.id);
   if (!report) return res.status(404).json({ ok: false, error: "Report not found" });
   res.json({ ok: true, report });
+};
+
+exports.getVetter = (req, res) => {
+  const email = req.session?.user?.email;
+  if (!email) return res.status(401).json({ ok: false, error: "Not authenticated" });
+  const vetter = getVetterState(email);
+  res.json({ ok: true, vetter });
+};
+
+exports.startVetter = (req, res) => {
+  const email = req.session?.user?.email;
+  if (!email) return res.status(401).json({ ok: false, error: "Not authenticated" });
+  const result = startVetterRun(email);
+  if (!result) {
+    return res.status(404).json({ ok: false, error: "User not found" });
+  }
+  if (result.alreadyActive) {
+    return res
+      .status(409)
+      .json({ ok: false, error: "InboxVetter is already running", vetter: result.vetter });
+  }
+  res.json({
+    ok: true,
+    vetter: result.vetter,
+    events: result.events,
+    report: result.report,
+  });
 };
 
 exports.getSettings = (req, res) => {

--- a/data/db.json
+++ b/data/db.json
@@ -31,6 +31,12 @@
           "connected": false,
           "updatedAt": null
         }
+      },
+      "vetter": {
+        "active": false,
+        "lastRunAt": null,
+        "lastReportId": null,
+        "logs": []
       }
     },
     {
@@ -64,6 +70,12 @@
           "connected": false,
           "updatedAt": null
         }
+      },
+      "vetter": {
+        "active": false,
+        "lastRunAt": null,
+        "lastReportId": null,
+        "logs": []
       }
     },
     {
@@ -97,6 +109,12 @@
           "connected": false,
           "updatedAt": null
         }
+      },
+      "vetter": {
+        "active": false,
+        "lastRunAt": null,
+        "lastReportId": null,
+        "logs": []
       }
     }
   ],

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -33,6 +33,7 @@
       </div>
       <div class="flex items-center gap-4">
         <span id="welcome" class="hidden sm:inline text-sm text-slate-600">Welcome, …</span>
+        <button id="unionBtn" class="text-sm px-3 py-1.5 rounded-lg border border-slate-300 hover:bg-slate-100">Union dashboard</button>
         <button id="settingsBtn" class="text-sm px-3 py-1.5 rounded-lg border border-slate-300 hover:bg-slate-100">Settings</button>
         <div class="flex items-center gap-2">
           <img id="avatar" class="h-8 w-8 rounded-full object-cover hidden" alt="avatar" />
@@ -181,6 +182,9 @@
       });
       document.getElementById('settingsBtn').addEventListener('click', () => {
         location.href = '/settings.html';
+      });
+      document.getElementById('unionBtn').addEventListener('click', () => {
+        location.href = '/union-dashboard.html';
       });
       document.getElementById('managePlanBtn').addEventListener('click', () => {
         location.href = '/settings.html#subscription';

--- a/public/report.html
+++ b/public/report.html
@@ -1,0 +1,177 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Union Report</title>
+  <script src="/theme.js"></script>
+  <script src="/config.js"></script>
+  <script src="/version.js" defer></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    html[data-theme="dark"] body { background-color: #0f172a; color: #e2e8f0; }
+    html[data-theme="dark"] header { background-color: #0b1220; border-color: #1f2937; }
+    html[data-theme="dark"] .bg-white { background-color: #0b1220 !important; }
+    html[data-theme="dark"] .bg-slate-50 { background-color: #0f172a !important; }
+    html[data-theme="dark"] .border-slate-200, html[data-theme="dark"] .border-slate-300 { border-color: #1f2937 !important; }
+    html[data-theme="dark"] .text-slate-900 { color: #e2e8f0 !important; }
+    html[data-theme="dark"] .text-slate-600, html[data-theme="dark"] .text-slate-500 { color: #94a3b8 !important; }
+  </style>
+</head>
+<body class="bg-slate-50 text-slate-900">
+  <header class="w-full bg-white border-b border-slate-200">
+    <div class="max-w-4xl mx-auto px-4 py-3 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <button id="backBtn" class="text-sm px-3 py-1.5 rounded-lg border border-slate-300 hover:bg-slate-100" type="button">← Back</button>
+        <div>
+          <h1 class="text-xl font-semibold">Union Report</h1>
+          <p class="text-xs text-slate-500" id="reportId">Loading…</p>
+        </div>
+      </div>
+      <div class="flex items-center gap-2">
+        <img id="avatar" class="h-8 w-8 rounded-full object-cover hidden" alt="avatar" />
+        <button id="logoutBtn" class="text-sm px-3 py-1.5 rounded-lg bg-slate-900 text-white hover:bg-slate-800">Log out</button>
+      </div>
+    </div>
+  </header>
+
+  <main class="max-w-4xl mx-auto px-4 py-6 space-y-6">
+    <section id="errorBox" class="hidden bg-red-100 border border-red-200 text-red-700 rounded-xl p-4 text-sm"></section>
+
+    <section class="bg-white border border-slate-200 rounded-xl p-6">
+      <p class="text-xs text-slate-500 uppercase tracking-wide">Overview</p>
+      <h2 id="reportTitle" class="mt-2 text-2xl font-semibold">Loading report…</h2>
+      <p id="reportMeta" class="mt-2 text-sm text-slate-600">—</p>
+      <p id="reportDescription" class="mt-4 text-base text-slate-700"></p>
+    </section>
+
+    <section id="highlightsSection" class="hidden bg-white border border-slate-200 rounded-xl p-6">
+      <div class="flex items-center justify-between">
+        <h3 class="text-lg font-semibold">Key highlights</h3>
+      </div>
+      <ul id="highlightsList" class="mt-4 space-y-3 list-disc pl-5"></ul>
+    </section>
+
+    <section id="actionsSection" class="hidden bg-white border border-slate-200 rounded-xl p-6">
+      <h3 class="text-lg font-semibold">Suggested next actions</h3>
+      <ul id="actionsList" class="mt-4 space-y-3 list-disc pl-5"></ul>
+    </section>
+  </main>
+
+  <script>
+    const fmtDate = (iso) => {
+      if (!iso) return '—';
+      try { return new Date(iso).toLocaleString(); } catch { return iso; }
+    };
+    const titleCase = (s = '') => s.replace(/\b([a-z])/g, (m) => m.toUpperCase());
+
+    async function api(path, opts) {
+      const res = await fetch(path, { credentials: 'include', ...opts });
+      if (res.status === 401) {
+        location.href = '/login.html';
+        throw new Error('Not authenticated');
+      }
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        const message = data?.error || data?.message || 'Request failed';
+        const err = new Error(message);
+        err.payload = data;
+        err.status = res.status;
+        throw err;
+      }
+      return data;
+    }
+
+    const params = new URLSearchParams(location.search);
+    const reportId = params.get('id');
+
+    const reportIdLabel = document.getElementById('reportId');
+    const reportTitle = document.getElementById('reportTitle');
+    const reportMeta = document.getElementById('reportMeta');
+    const reportDescription = document.getElementById('reportDescription');
+    const highlightsSection = document.getElementById('highlightsSection');
+    const highlightsList = document.getElementById('highlightsList');
+    const actionsSection = document.getElementById('actionsSection');
+    const actionsList = document.getElementById('actionsList');
+    const errorBox = document.getElementById('errorBox');
+
+    function showError(message) {
+      errorBox.textContent = message;
+      errorBox.classList.remove('hidden');
+    }
+
+    function renderReport(report) {
+      reportIdLabel.textContent = report.id || 'Unknown report';
+      reportTitle.textContent = report.title || 'Union report';
+      const status = titleCase((report.status || 'completed').replace(/[._-]+/g, ' '));
+      reportMeta.textContent = `${status} • ${fmtDate(report.createdAt)}`;
+      reportDescription.textContent = report.description || report.snippet || 'No description available.';
+
+      const highlights = report.meta?.highlights || [];
+      const actions = report.meta?.actions || [];
+
+      if (highlights.length) {
+        highlightsSection.classList.remove('hidden');
+        highlightsList.innerHTML = '';
+        highlights.forEach((item) => {
+          const li = document.createElement('li');
+          li.textContent = item;
+          highlightsList.appendChild(li);
+        });
+      }
+      if (actions.length) {
+        actionsSection.classList.remove('hidden');
+        actionsList.innerHTML = '';
+        actions.forEach((item) => {
+          const li = document.createElement('li');
+          li.textContent = item;
+          actionsList.appendChild(li);
+        });
+      }
+    }
+
+    async function bootstrap() {
+      if (!reportId) {
+        showError('Missing report id.');
+        reportTitle.textContent = 'No report selected';
+        return;
+      }
+      reportIdLabel.textContent = reportId;
+
+      const meResp = await api('/api/me');
+      const me = meResp.user || {};
+      if (me.picture) {
+        const avatar = document.getElementById('avatar');
+        avatar.src = me.picture;
+        avatar.classList.remove('hidden');
+      }
+
+      try {
+        const reportResp = await api(`/api/reports/${encodeURIComponent(reportId)}`);
+        renderReport(reportResp.report || {});
+      } catch (err) {
+        showError(err.message || 'Failed to load report.');
+        reportTitle.textContent = 'Unable to load report';
+      }
+    }
+
+    document.getElementById('backBtn').addEventListener('click', () => {
+      if (document.referrer && document.referrer.startsWith(window.location.origin)) {
+        history.back();
+      } else {
+        location.href = '/union-dashboard.html';
+      }
+    });
+
+    document.getElementById('logoutBtn').addEventListener('click', async () => {
+      await fetch('/auth/logout', { method: 'POST', credentials: 'include' });
+      location.href = '/login.html';
+    });
+
+    bootstrap().catch((err) => {
+      console.error(err);
+      showError('Failed to load report: ' + err.message);
+    });
+  </script>
+</body>
+</html>

--- a/public/union-dashboard.html
+++ b/public/union-dashboard.html
@@ -1,0 +1,320 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Union Dashboard</title>
+  <script src="/theme.js"></script>
+  <script src="/config.js"></script>
+  <script src="/version.js" defer></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    html[data-theme="dark"] body { background-color: #0f172a; color: #e2e8f0; }
+    html[data-theme="dark"] header { background-color: #0b1220; border-color: #1f2937; }
+    html[data-theme="dark"] .bg-slate-50 { background-color: #0f172a !important; }
+    html[data-theme="dark"] .bg-white { background-color: #0b1220 !important; }
+    html[data-theme="dark"] .text-slate-900 { color: #e2e8f0 !important; }
+    html[data-theme="dark"] .text-slate-600, html[data-theme="dark"] .text-slate-500 { color: #94a3b8 !important; }
+    html[data-theme="dark"] .border-slate-200, html[data-theme="dark"] .border-slate-300 { border-color: #1f2937 !important; }
+    html[data-theme="dark"] select, html[data-theme="dark"] input, html[data-theme="dark"] button { background-color: #0b1220; color: #e2e8f0; border-color: #334155; }
+    html[data-theme="dark"] .hover\:bg-slate-100:hover { background-color: #111827 !important; }
+    html[data-theme="dark"] .bg-emerald-50 { background-color: rgba(16, 185, 129, 0.15) !important; }
+    html[data-theme="dark"] .bg-red-50 { background-color: rgba(248, 113, 113, 0.12) !important; }
+  </style>
+</head>
+<body class="bg-slate-50 text-slate-900">
+  <header class="w-full bg-white border-b border-slate-200">
+    <div class="max-w-6xl mx-auto px-4 py-3 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <div class="h-8 w-8 rounded-xl bg-indigo-600"></div>
+        <div>
+          <h1 class="text-xl font-semibold">InboxVetter</h1>
+          <p class="text-xs text-slate-500" id="planBadge">Loading plan…</p>
+        </div>
+      </div>
+      <div class="flex items-center gap-4">
+        <span id="welcome" class="hidden sm:inline text-sm text-slate-600">Welcome, …</span>
+        <button id="dashboardBtn" class="text-sm px-3 py-1.5 rounded-lg border border-slate-300 hover:bg-slate-100">Main dashboard</button>
+        <button id="settingsBtn" class="text-sm px-3 py-1.5 rounded-lg border border-slate-300 hover:bg-slate-100">Settings</button>
+        <div class="flex items-center gap-2">
+          <img id="avatar" class="h-8 w-8 rounded-full object-cover hidden" alt="avatar" />
+          <button id="logoutBtn" class="text-sm px-3 py-1.5 rounded-lg bg-slate-900 text-white hover:bg-slate-800">Log out</button>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <main class="max-w-6xl mx-auto px-4 py-6 space-y-6">
+    <section class="bg-white border border-slate-200 rounded-xl p-5">
+      <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+        <div>
+          <p class="text-sm text-slate-500">InboxVetter status</p>
+          <div class="mt-2 flex items-center gap-2">
+            <span id="statusDot" class="h-2.5 w-2.5 rounded-full bg-slate-300"></span>
+            <span id="statusLabel" class="text-lg font-semibold">Checking…</span>
+          </div>
+          <p id="lastRun" class="mt-1 text-sm text-slate-600">Last run: —</p>
+          <button id="lastReport" class="mt-2 hidden text-sm text-indigo-600 hover:underline" type="button"></button>
+        </div>
+        <div class="flex flex-col items-stretch sm:flex-row sm:items-center gap-3">
+          <button id="startBtn" class="text-sm px-4 py-2 rounded-lg bg-indigo-600 text-white hover:bg-indigo-500 disabled:opacity-60 disabled:cursor-not-allowed">Start</button>
+        </div>
+      </div>
+    </section>
+
+    <section class="bg-white border border-slate-200 rounded-xl p-5">
+      <div class="flex items-center justify-between gap-2">
+        <h2 class="text-lg font-semibold">Activity log</h2>
+        <span id="logCount" class="text-xs text-slate-500">0 entries</span>
+      </div>
+      <div class="mt-4 max-h-72 overflow-y-auto border border-slate-200 rounded-lg bg-slate-50 p-4">
+        <div id="logEmpty" class="text-sm text-slate-500">No activity yet. Start a run to see real-time progress.</div>
+        <ul id="logList" class="space-y-3"></ul>
+      </div>
+    </section>
+
+    <section class="bg-white border border-slate-200 rounded-xl p-5">
+      <div class="mb-4 flex items-center justify-between">
+        <h2 class="text-lg font-semibold">Generated reports</h2>
+        <p id="reportCount" class="text-xs text-slate-500">0 reports</p>
+      </div>
+      <div id="reportsEmpty" class="bg-white border border-dashed border-slate-300 rounded-xl p-6 text-center text-slate-500">
+        No reports yet. Start a vetter run to generate your first summary.
+      </div>
+      <ul id="reportsList" class="grid md:grid-cols-2 gap-4"></ul>
+    </section>
+  </main>
+
+  <template id="logRow">
+    <li class="bg-white border border-slate-200 rounded-lg p-3 shadow-sm">
+      <div class="flex items-start justify-between gap-3">
+        <p class="text-sm text-slate-600"></p>
+        <span class="text-xs text-slate-400 whitespace-nowrap"></span>
+      </div>
+    </li>
+  </template>
+
+  <template id="reportRow">
+    <li>
+      <button type="button" class="w-full text-left bg-white border border-slate-200 rounded-xl p-4 hover:shadow-md transition">
+        <div class="flex items-start justify-between gap-4">
+          <div>
+            <h3 class="font-medium text-slate-900 line-clamp-1"></h3>
+            <p class="mt-1 text-sm text-slate-600"></p>
+            <p class="mt-1 text-xs text-slate-500"></p>
+          </div>
+          <span class="inline-flex items-center text-xs px-2 py-1 rounded-full bg-emerald-100 text-emerald-700">View</span>
+        </div>
+      </button>
+    </li>
+  </template>
+
+  <script>
+    const fmtDate = (iso) => {
+      if (!iso) return '—';
+      try {
+        return new Date(iso).toLocaleString();
+      } catch {
+        return iso;
+      }
+    };
+    const titleCase = (s = '') => s.replace(/\b([a-z])/g, (m) => m.toUpperCase());
+    const planName = (slug) => {
+      const raw = (slug || '').toLowerCase();
+      if (!raw) return 'Free';
+      if (['creator', 'base', 'basic_tier'].includes(raw)) return 'Basic';
+      if (['team', 'premium', 'pro_tier'].includes(raw)) return 'Pro';
+      if (raw === 'free') return 'Free';
+      return titleCase(raw.replace(/[._-]+/g, ' '));
+    };
+
+    async function api(path, opts) {
+      const res = await fetch(path, { credentials: 'include', ...opts });
+      if (res.status === 401) {
+        location.href = '/login.html';
+        return Promise.reject(new Error('Not authenticated'));
+      }
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        const message = data?.error || data?.message || 'Request failed';
+        const err = new Error(message);
+        err.status = res.status;
+        err.payload = data;
+        throw err;
+      }
+      return data;
+    }
+
+    const statusDot = document.getElementById('statusDot');
+    const statusLabel = document.getElementById('statusLabel');
+    const lastRunEl = document.getElementById('lastRun');
+    const lastReportBtn = document.getElementById('lastReport');
+    const startBtn = document.getElementById('startBtn');
+    const logList = document.getElementById('logList');
+    const logEmpty = document.getElementById('logEmpty');
+    const logCount = document.getElementById('logCount');
+    const logTpl = document.getElementById('logRow');
+    const reportsList = document.getElementById('reportsList');
+    const reportsEmpty = document.getElementById('reportsEmpty');
+    const reportCount = document.getElementById('reportCount');
+    const reportTpl = document.getElementById('reportRow');
+
+    let vetterState = { active: false, lastRunAt: null, lastReportId: null, logs: [] };
+    let logs = [];
+    let reports = [];
+
+    function renderStatus(state) {
+      const active = Boolean(state?.active);
+      statusDot.className = 'h-2.5 w-2.5 rounded-full ' + (active ? 'bg-emerald-500' : 'bg-slate-300');
+      statusLabel.textContent = active ? 'Active' : 'Idle';
+      lastRunEl.textContent = `Last run: ${fmtDate(state?.lastRunAt)}`;
+      if (state?.lastReportId) {
+        lastReportBtn.classList.remove('hidden');
+        lastReportBtn.textContent = 'Open last report';
+        lastReportBtn.dataset.reportId = state.lastReportId;
+      } else {
+        lastReportBtn.classList.add('hidden');
+        delete lastReportBtn.dataset.reportId;
+      }
+    }
+
+    function renderLogs() {
+      const entries = logs.slice().sort((a, b) => new Date(a.timestamp) - new Date(b.timestamp));
+      logList.innerHTML = '';
+      if (!entries.length) {
+        logEmpty.classList.remove('hidden');
+      } else {
+        logEmpty.classList.add('hidden');
+      }
+      logCount.textContent = `${entries.length} entr${entries.length === 1 ? 'y' : 'ies'}`;
+      for (const entry of entries) {
+        const node = logTpl.content.cloneNode(true);
+        const container = node.querySelector('li');
+        const level = (entry.level || 'info').toLowerCase();
+        if (level === 'error') {
+          container.classList.add('border-red-200', 'bg-red-50');
+        } else if (level === 'success') {
+          container.classList.add('border-emerald-200', 'bg-emerald-50');
+        }
+        node.querySelector('p').textContent = entry.message || '';
+        node.querySelector('span').textContent = fmtDate(entry.timestamp);
+        logList.appendChild(node);
+      }
+      if (logList.lastElementChild) {
+        logList.lastElementChild.scrollIntoView({ behavior: 'smooth', block: 'end' });
+      }
+    }
+
+    function pushLog(entry) {
+      if (!entry) return;
+      logs.push(entry);
+      if (logs.length > 100) logs = logs.slice(-100);
+      renderLogs();
+    }
+
+    function renderReports() {
+      const items = reports.slice().sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+      reportsList.innerHTML = '';
+      reportCount.textContent = `${items.length} report${items.length === 1 ? '' : 's'}`;
+      if (!items.length) {
+        reportsEmpty.classList.remove('hidden');
+        return;
+      }
+      reportsEmpty.classList.add('hidden');
+      for (const report of items) {
+        const node = reportTpl.content.cloneNode(true);
+        node.querySelector('h3').textContent = report.title || report.id;
+        node.querySelector('p:nth-of-type(1)').textContent = report.description || report.snippet || '';
+        const status = titleCase((report.status || 'completed').replace(/[._-]+/g, ' '));
+        node.querySelector('p:nth-of-type(2)').textContent = `${status} • ${fmtDate(report.createdAt)}`;
+        const button = node.querySelector('button');
+        button.addEventListener('click', () => {
+          location.href = `/report.html?id=${encodeURIComponent(report.id)}`;
+        });
+        reportsList.appendChild(node);
+      }
+    }
+
+    async function bootstrap() {
+      const meResp = await api('/api/me');
+      const me = meResp.user || {};
+      document.getElementById('welcome').textContent = `Welcome, ${me.name?.split(' ')[0] || 'Friend'}!`;
+      document.getElementById('welcome').classList.remove('hidden');
+      document.getElementById('planBadge').textContent = `${planName(me.plan)} plan`;
+      if (me.picture) {
+        const img = document.getElementById('avatar');
+        img.src = me.picture;
+        img.classList.remove('hidden');
+      }
+
+      const vetterResp = await api('/api/vetter');
+      vetterState = vetterResp.vetter || vetterState;
+      logs = Array.isArray(vetterState.logs) ? vetterState.logs.slice() : [];
+      renderStatus(vetterState);
+      renderLogs();
+
+      const reportsResp = await api('/api/reports');
+      reports = Array.isArray(reportsResp.reports) ? reportsResp.reports.slice() : [];
+      renderReports();
+    }
+
+    startBtn.addEventListener('click', async () => {
+      if (startBtn.disabled) return;
+      startBtn.disabled = true;
+      startBtn.textContent = 'Running…';
+      renderStatus({ ...vetterState, active: true });
+      pushLog({ id: `client-${Date.now()}`, level: 'info', message: 'Requesting new vetter run…', timestamp: new Date().toISOString() });
+      try {
+        const payload = await api('/api/vetter/start', { method: 'POST' });
+        const events = Array.isArray(payload.events) ? payload.events : [];
+        for (const entry of events) {
+          pushLog(entry);
+          await new Promise((resolve) => setTimeout(resolve, 300));
+        }
+        vetterState = payload.vetter || vetterState;
+        logs = Array.isArray(vetterState.logs) ? vetterState.logs.slice() : logs;
+        renderStatus(vetterState);
+        renderLogs();
+        if (payload.report) {
+          reports = [payload.report, ...reports.filter((r) => r.id !== payload.report.id)];
+          renderReports();
+        }
+      } catch (err) {
+        if (err.payload?.vetter) {
+          vetterState = err.payload.vetter;
+          logs = Array.isArray(vetterState.logs) ? vetterState.logs.slice() : logs;
+        }
+        pushLog({ id: `err-${Date.now()}`, level: 'error', message: err.message || 'Failed to start vetter.', timestamp: new Date().toISOString() });
+        renderStatus(vetterState);
+      } finally {
+        startBtn.disabled = false;
+        startBtn.textContent = 'Start';
+        renderStatus(vetterState);
+      }
+    });
+
+    lastReportBtn.addEventListener('click', () => {
+      const id = lastReportBtn.dataset.reportId;
+      if (id) {
+        location.href = `/report.html?id=${encodeURIComponent(id)}`;
+      }
+    });
+
+    document.getElementById('logoutBtn').addEventListener('click', async () => {
+      await fetch('/auth/logout', { method: 'POST', credentials: 'include' });
+      location.href = '/login.html';
+    });
+    document.getElementById('settingsBtn').addEventListener('click', () => {
+      location.href = '/settings.html';
+    });
+    document.getElementById('dashboardBtn').addEventListener('click', () => {
+      location.href = '/dashboard.html';
+    });
+
+    bootstrap().catch((err) => {
+      console.error(err);
+      alert('Failed to load union dashboard: ' + err.message);
+    });
+  </script>
+</body>
+</html>

--- a/routes/api.js
+++ b/routes/api.js
@@ -8,11 +8,15 @@ const {
   updateSettings,
   listReports,
   getReport,
+  getVetter,
+  startVetter,
 } = require("../controllers/apiController");
 
 router.get("/me", requireAuth, getMe);
 router.get("/reports", requireAuth, listReports);
 router.get("/reports/:id", requireAuth, getReport);
+router.get("/vetter", requireAuth, getVetter);
+router.post("/vetter/start", requireAuth, startVetter);
 router.get("/settings", requireAuth, getSettings);
 router.post("/settings", requireAuth, updateSettings);
 

--- a/server.js
+++ b/server.js
@@ -125,6 +125,14 @@ app.get(["/settings", "/settings.html"], sessionMiddleware.requireAuth, (_, res)
 app.get(["/supportme", "/supportme.html"], sessionMiddleware.requireAuth, (_, res) =>
   res.sendFile(path.join(PUB, "supportme.html"))
 );
+app.get(
+  ["/union", "/union.html", "/union-dashboard", "/union-dashboard.html"],
+  sessionMiddleware.requireAuth,
+  (_, res) => res.sendFile(path.join(PUB, "union-dashboard.html"))
+);
+app.get(["/report", "/report.html"], sessionMiddleware.requireAuth, (_, res) =>
+  res.sendFile(path.join(PUB, "report.html"))
+);
 
 // ───────────────────────────────────────────────────────────────────────────────
 // routes


### PR DESCRIPTION
## Summary
- extend the data store and API to persist per-user vetter status, logs, and simulated run output
- add a protected union dashboard page with vetter start control, live activity log, and generated report list
- create a detailed report viewer page and link to the new dashboard from the main experience

## Testing
- npm run start


------
https://chatgpt.com/codex/tasks/task_e_68cb1b73b294832aa1f56e713d56bdb8